### PR TITLE
Add notes on how to set the BOT_PASSWD

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -27,7 +27,9 @@ In this closed room administrative commands can be executed.
 | !update-config  | Updates the bot configuration by executing `update_config_command` command |
 
 ### Configuration
-In order to use the bot, two configuration files are required. The `config.toml` configuration file contains the bot settings (e.g. username/password, room ids, ...) and the definitions for the sections and projects. The second configuration file `template.md` serves as a template for the actual summary.
+In order to use the bot, two configuration files are required. The `config.toml` configuration file contains the bot settings (username, room ids, etc) and the definitions for the sections and projects. The second configuration file `template.md` serves as a template for the actual summary.
+
+The password for the bot is supplied via the `BOT_PASSWORD` environment variable. Setting this will depend on how you start the bot. 
 
 For both configuration files, examples are available that can be used as templates (see `example_config` folder). 
 
@@ -36,4 +38,4 @@ More configuration examples:
 
 ### Deployment
 The bot is available as [docker image](https://hub.docker.com/r/haeckerfelix/hebbot).
-You can find an example `docker-compose.yml` inside the `example_config` folder.
+You can find an example `docker-compose.yml` inside the `example_config` folder. Be sure to set the `BOT_PASSWORD` variable correctly before using it.

--- a/doc/example_config/config.toml
+++ b/doc/example_config/config.toml
@@ -1,4 +1,5 @@
 bot_user_id = '@botname:domain.org'
+# bot password is specified via the BOT_PASSWORD environment variable
 reporting_room_id = '!roomid:domain.org'
 admin_room_id = '!adminroomid:domain.org'
 notice_emoji = '⭕'


### PR DESCRIPTION
When I last updated the Docker container, the password was still contained in the config file. I assume it was moved so that the config file could be published (for use with `!update_cofnig`) but it took me some while to work out where it had gone :stuck_out_tongue: 

This PR ties to improve the docs, but further suggestions are welcome!