### PR TITLE
Fixes #49, #54 - React to displayname and remove it from the message

### DIFF
--- a/src/bot.rs
+++ b/src/bot.rs
@@ -287,9 +287,11 @@ impl Bot {
         member: &RoomMember,
         event_id: &EventId,
     ) {
-        // We're going to ignore all messages, expect it mentions the bot at the beginning
+        // We're going to ignore all messages, except if it mentions the bot at
+        // the beginning by name or id
         let bot_id = self.client.user_id().await.unwrap();
-        if !utils::msg_starts_with_mention(bot_id, message.clone()) {
+        let display_name = self.client.display_name().await.unwrap();
+        if !utils::msg_starts_with_mention(bot_id, display_name, message.clone()) {
             return;
         }
 
@@ -316,7 +318,8 @@ impl Bot {
     ) {
         let event_id = edited_msg_event_id.to_string();
         let bot = self.client.user_id().await.unwrap();
-        let updated_message = utils::remove_bot_name(&updated_message, &bot);
+        let display_name = self.client.display_name().await.unwrap();
+        let updated_message = utils::remove_bot_name(&updated_message, &bot, display_name);
         let link = self.message_link(edited_msg_event_id.to_string());
 
         let message = {
@@ -934,7 +937,12 @@ impl Bot {
 
             // remove bot name from message
             let bot_id = self.client.user_id().await.unwrap();
-            news.set_message(utils::remove_bot_name(&news.message(), &bot_id));
+            let display_name = self.client.display_name().await.unwrap();
+            news.set_message(utils::remove_bot_name(
+                &news.message(),
+                &bot_id,
+                display_name,
+            ));
 
             // Pre-populate with emojis to facilitate the editor's work
             for project in self.config.projects_by_usual_reporter(&news.reporter_id) {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -118,11 +118,17 @@ pub fn get_member_display_name(member: &BaseRoomMember) -> String {
 
 /// Checks if a message starts with a user_id mention
 /// Automatically handles @ in front of the name
-pub fn msg_starts_with_mention(user_id: UserId, msg: String) -> bool {
+pub fn msg_starts_with_mention(
+    user_id: UserId,
+    displayname: std::option::Option<String>,
+    msg: String,
+) -> bool {
+    let displayname = displayname.unwrap().to_lowercase(); // Why do I have to unwrap twice?
     let localpart = user_id.localpart().to_lowercase();
     // Catch "@botname ..." messages
     let msg = msg.replace(&format!("@{}", localpart), &localpart);
     msg.as_str().to_lowercase().starts_with(&localpart)
+        || (!displayname.is_empty() && msg.as_str().to_lowercase().starts_with(&displayname))
 }
 
 /// Returns `true` if the emojis are matching
@@ -133,10 +139,19 @@ pub fn emoji_cmp(a: &str, b: &str) -> bool {
 }
 
 /// Remove bot name from message
-pub fn remove_bot_name(message: &str, bot: &UserId) -> String {
-    let regex = format!("(?i)^@?{}(:{})?:?", bot.localpart(), bot.server_name());
+pub fn remove_bot_name(
+    message: &str,
+    bot: &UserId,
+    displayname: std::option::Option<String>,
+) -> String {
+    let displayname = displayname.unwrap(); // Why do I have to unwrap twice?
+    let regex = format!("(?i)^{}:?", &displayname);
     let re = Regex::new(&regex).unwrap();
     let message = re.replace(message, "");
+
+    let regex = format!("(?i)^@?{}(:{})?:?", bot.localpart(), bot.server_name());
+    let re = Regex::new(&regex).unwrap();
+    let message = re.replace(&message, "");
     message.trim().to_string()
 }
 


### PR DESCRIPTION
This is my first attempt to do anything serious with Rust, and I suspect I'm breaking a lot of rules. However, it appears to work, so hopefully we can tidy it up. Examples:

Reporting room:
```
Gwmngilfen: newsbot 🗞️: this report is using a display name!
newsbot 🗞️: ✅ Thanks for the report Gwmngilfen, I'll store your update!
Gwmngilfen: @hebbot:mydomain.org this report is using a full id
newsbot 🗞️: ✅ Thanks for the report Gwmngilfen, I'll store your update!
Gwmngilfen: hebbot this report is using a localpart only
newsbot 🗞️: ✅ Thanks for the report Gwmngilfen, I'll store your update!
```

Rendered MD:
```
[Gwmngilfen](https://matrix.to/#/@gwmngilfen:ansible.im) says
> this report is using a full id

[Gwmngilfen](https://matrix.to/#/@gwmngilfen:ansible.im) says
> this report is using a localpart only

[Gwmngilfen](https://matrix.to/#/@gwmngilfen:ansible.im) reports
> this report is using a display name!
```

The code is really ugly. In particular, I think I *should* just pass the whole `Bot` object to `msg_starts_with_mention` and then extract the `user_id` and `displayname` inside - but I couldn't work out how to make the type-checking work with that. Instead I'm left with a lot of string unwrapping that is fairly nasty.

Also, I see there's a nice method to get display names for reporters - but that requires a RoomMember object, which the bot is not - could that be reused in some way?

Looking forward to the feedback!