### PR TITLE
Allow for custom ack messages

### DIFF
--- a/doc/example_config/config.toml
+++ b/doc/example_config/config.toml
@@ -6,6 +6,7 @@ notice_emoji = '⭕'
 image_markdown = '> ![]({{file}})'
 video_markdown = '> {{< video src="{{file}}" >}}'
 verbs = ["reports", "says", "announces"]
+ack_text = "✅ Thanks for the report {{user}}, I'll store your update!" # set to '' to disable text response
 update_config_command = "sh /data/update_config.sh"
 editors = [
     '@user1:domain.io',

--- a/src/bot.rs
+++ b/src/bot.rs
@@ -919,12 +919,12 @@ impl Bot {
 
         // Check min message length
         if news.message().len() > 30 {
-            if notify_reporter {
-                let msg = format!(
-                    "✅ Thanks for the report {}, I'll store your update!",
-                    news.reporter_display_name
-                );
-                self.send_message(&msg, BotMsgType::ReportingRoomPlainNotice)
+            if notify_reporter && !self.config.ack_text.is_empty() {
+                let msg = &self
+                    .config
+                    .ack_text
+                    .replace("{{user}}", &news.reporter_display_name);
+                self.send_message(msg, BotMsgType::ReportingRoomPlainNotice)
                     .await;
             }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -14,6 +14,7 @@ pub struct Config {
     pub image_markdown: String,
     pub video_markdown: String,
     pub verbs: Vec<String>,
+    pub ack_text: String,
     pub update_config_command: String,
     pub editors: Vec<String>,
     pub sections: Vec<Section>,


### PR DESCRIPTION
Some communities may find the hard-coded "Thanks for your message" not to their taste. This patch allows for it to be set in config, and to disable it by setting it to "".

As ever, my Rust is terrible, so feedback welcome :)