### PR TITLE
make length check configurable and not count the bot name

### DIFF
--- a/doc/example_config/config.toml
+++ b/doc/example_config/config.toml
@@ -6,6 +6,7 @@ notice_emoji = '⭕'
 image_markdown = '> ![]({{file}})'
 video_markdown = '> {{< video src="{{file}}" >}}'
 verbs = ["reports", "says", "announces"]
+min_length = 30
 update_config_command = "sh /data/update_config.sh"
 editors = [
     '@user1:domain.io',

--- a/src/bot.rs
+++ b/src/bot.rs
@@ -917,8 +917,12 @@ impl Bot {
             return;
         }
 
+        // remove bot name from message before we check length
+        let bot_id = self.client.user_id().await.unwrap();
+        news.set_message(utils::remove_bot_name(&news.message(), &bot_id));
+
         // Check min message length
-        if news.message().len() > 30 {
+        if news.message().len() > self.config.min_length {
             if notify_reporter {
                 let msg = format!(
                     "✅ Thanks for the report {}, I'll store your update!",
@@ -931,10 +935,6 @@ impl Bot {
             let msg = format!("✅ {} submitted a news entry. [{}]", news.reporter_id, link);
             self.send_message(&msg, BotMsgType::AdminRoomHtmlNotice)
                 .await;
-
-            // remove bot name from message
-            let bot_id = self.client.user_id().await.unwrap();
-            news.set_message(utils::remove_bot_name(&news.message(), &bot_id));
 
             // Pre-populate with emojis to facilitate the editor's work
             for project in self.config.projects_by_usual_reporter(&news.reporter_id) {

--- a/src/config.rs
+++ b/src/config.rs
@@ -14,6 +14,7 @@ pub struct Config {
     pub image_markdown: String,
     pub video_markdown: String,
     pub verbs: Vec<String>,
+    pub min_length: usize,
     pub update_config_command: String,
     pub editors: Vec<String>,
     pub sections: Vec<Section>,


### PR DESCRIPTION
Sometimes it's OK to have short news items, it's dependant on the community. This PR makes it configurable.

While testing, I noticed the bot name is included in the message length (my bot has a long domain, so even a news item of "foo" will be more than 30 chars :P) so I've attempted to fix that as well.