### PR TITLE
Allow the bot to respond to reports with a reaction

### DIFF
--- a/doc/example_config/config.toml
+++ b/doc/example_config/config.toml
@@ -3,6 +3,7 @@ bot_user_id = '@botname:domain.org'
 reporting_room_id = '!roomid:domain.org'
 admin_room_id = '!adminroomid:domain.org'
 notice_emoji = '⭕'
+ack_emoji = '✅'   # set to '' to disable
 image_markdown = '> ![]({{file}})'
 video_markdown = '> {{< video src="{{file}}" >}}'
 verbs = ["reports", "says", "announces"]

--- a/src/bot.rs
+++ b/src/bot.rs
@@ -919,6 +919,14 @@ impl Bot {
 
         // Check min message length
         if news.message().len() > 30 {
+            // React with ack_emoji if configured
+            if !self.config.ack_emoji.is_empty() {
+                self.send_reaction(
+                    &self.config.ack_emoji,
+                    &EventId::try_from(news.event_id.as_str()).unwrap(),
+                )
+                .await;
+            }
             if notify_reporter {
                 let msg = format!(
                     "✅ Thanks for the report {}, I'll store your update!",

--- a/src/config.rs
+++ b/src/config.rs
@@ -11,6 +11,7 @@ pub struct Config {
     pub reporting_room_id: String,
     pub admin_room_id: String,
     pub notice_emoji: String,
+    pub ack_emoji: String,
     pub image_markdown: String,
     pub video_markdown: String,
     pub verbs: Vec<String>,


### PR DESCRIPTION
In some circumstances it is nice to have some indication that the bot saw your report via reactions - especially where there is heavy use of `notice_emoji` which suppresses the text acknowledgement.

This PR adds an `ack_emoji`, and allows for it to be disbled in the config. Best paired with #62 which would allow you to either disabled all text and just use reactions, or disable reactions and just use text, or a mix of both.