### PR TITLE
render: Insert quoted newline before every media

### DIFF
--- a/src/render.rs
+++ b/src/render.rs
@@ -330,11 +330,11 @@ fn render_news_md(news: &News, config: &Config) -> String {
     // Insert images/videos into markdown > quote, separating it from any elements before it
     for (filename, _) in news.images() {
         let image = config.image_markdown.replace("{{file}}", &filename);
-        news_md += &("\n>" + image.clone() + "\n");
+        news_md += &("\n>".to_owned() + &image.clone() + "\n");
     }
     for (filename, _) in news.videos() {
         let video = config.video_markdown.replace("{{file}}", &filename);
-        news_md += &("\n>" + video.clone() + "\n");
+        news_md += &("\n>".to_owned() + &video.clone() + "\n");
     }
 
     news_md += "\n";

--- a/src/render.rs
+++ b/src/render.rs
@@ -330,7 +330,7 @@ fn render_news_md(news: &News, config: &Config) -> String {
     // Insert images/videos into markdown > quote, separating it from any elements before it
     for (filename, _) in news.images() {
         let image = config.image_markdown.replace("{{file}}", &filename);
-        news_md += &("\n>" +image.clone() + "\n");
+        news_md += &("\n>" + image.clone() + "\n");
     }
     for (filename, _) in news.videos() {
         let video = config.video_markdown.replace("{{file}}", &filename);

--- a/src/render.rs
+++ b/src/render.rs
@@ -327,14 +327,14 @@ fn render_news_md(news: &News, config: &Config) -> String {
         user, verb, message
     );
 
-    // Insert images/videos into markdown > quote
+    // Insert images/videos into markdown > quote, separating it from any elements before it
     for (filename, _) in news.images() {
         let image = config.image_markdown.replace("{{file}}", &filename);
-        news_md += &(image.clone() + "\n");
+        news_md += &("\n>" +image.clone() + "\n");
     }
     for (filename, _) in news.videos() {
         let video = config.video_markdown.replace("{{file}}", &filename);
-        news_md += &(video.clone() + "\n");
+        news_md += &("\n>" + video.clone() + "\n");
     }
 
     news_md += "\n";


### PR DESCRIPTION
Intended to fix [#78](https://github.com/haecker-felix/hebbot/issues/78)

I have no idea how to test this, and I haven't verified that it works, but from what I gather it _ought_ to do the trick.

__What changed__

Basically, what rendered to this markdown before:

```markdown
> this changed:
>
> * Blah
> ![](nice_media)
```

now renders to this:

```markdown
> this changed:
>
> * Blah
>
> ![](nice_media)
```

This will always happen, not just when the element before is a list:

```markdown
> Announcement!
> ![](nice_media)
```

becomes

```markdown
> Announcement!
>
> ![](nice_media)
```

but that shouldn't make a difference.