### PR TITLE
Honor HOMESERVER_URL environment variable

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -30,6 +30,8 @@ In order to use the bot, two configuration files are required. The `config.toml`
 
 The password for the bot is supplied via the `BOT_PASSWORD` environment variable. Setting this will depend on how you start the bot. 
 
+If the bot cannot determine the URL of the home server from the `bot_user_id` setting, it may be supplied by the `HOMESERVER_URL` environment variable.
+
 For both configuration files, examples are available that can be used as templates (see `example_config` folder). 
 
 More configuration examples:

--- a/src/bot.rs
+++ b/src/bot.rs
@@ -44,12 +44,14 @@ impl Bot {
         let user = UserId::parse(username).expect("Unable to parse bot user id");
         let server_name = ServerName::parse(user.server_name()).unwrap();
         let request_config = RequestConfig::new().force_auth();
-        let client = Client::builder()
+
+        let mut client_builder = Client::builder()
             .server_name(&server_name)
-            .request_config(request_config)
-            .build()
-            .await
-            .unwrap();
+            .request_config(request_config);
+        if let Ok(value) = env::var("HOMESERVER_URL") {
+            client_builder = client_builder.homeserver_url(value);
+        }
+        let client = client_builder.build().await.unwrap();
 
         Self::login(&client, user.localpart(), &password).await;
 


### PR DESCRIPTION
Use the value of the `HOMESERVER_URL` environment variable when defined. This allows the bot to work when the URL cannot be derived from the `bot_user_id` configuration file entry.