### PR TITLE
Remove hardcoded RUST_LOG environment variable value

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -24,8 +24,6 @@ pub use section::Section;
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() {
-    std::env::set_var("RUST_LOG", "debug");
-
     pretty_env_logger::init_timed();
 
     info!("Starting hebbot");


### PR DESCRIPTION
Remove setting the RUST_LOG variable to a hardcoded value at startup. This allows choosing the desired logging level, filtering logs per crate, and avoids the chatty debug log level in production setups.