### PR TITLE
Retry login after intervals specified by the server

### DIFF
--- a/src/bot.rs
+++ b/src/bot.rs
@@ -893,7 +893,7 @@ impl Bot {
     async fn restart_command(&self) {
         self.send_message("Restarting hebbot…", BotMsgType::AdminRoomPlainNotice)
             .await;
-        Command::new("/proc/self/exe").exec();
+        let _ = Command::new("/proc/self/exe").exec();
     }
 
     async fn say_command(&self, msg: &str) {


### PR DESCRIPTION
Sleep for the duration indicated by the server on `M_LIMIT_EXCEEDED` responses, or immediately if no time specified.