### PR TITLE
feat: add `!publish_command`

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -17,6 +17,7 @@ pub struct Config {
     pub min_length: usize,
     pub ack_text: String,
     pub update_config_command: String,
+    pub publish_command: Option<String>,
     pub editors: Vec<OwnedUserId>,
     pub sections: Vec<Section>,
     pub projects: Vec<Project>,


### PR DESCRIPTION
Add an optional `!publish_command` that can be configured. It will get the generated rendered markdown through stdin. If the command has some output it will be sent to the admin channel as a message.

This can be useful for more robust publishing practices.