### PR TITLE
Update Dockerfile base image to bookworm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Build stage
 
-FROM rust:bookworm as cargo-build
+FROM rust:bookworm AS cargo-build
 RUN apt-get update && apt-get -y install libolm-dev cmake
 
 WORKDIR /usr/src/hebbot

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN cargo install --locked --path .
 # Final stage
 
 FROM debian:stable-slim
-RUN apt-get update && apt-get -y install libssl-dev ca-certificates wget curl git
+RUN apt-get update && apt-get -y install libssl-dev ca-certificates wget curl git libsqlite3-0
 
 COPY --from=cargo-build /usr/local/cargo/bin/hebbot /bin
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Build stage
 
-FROM rust:buster as cargo-build
+FROM rust:bookworm as cargo-build
 RUN apt-get update && apt-get -y install libolm-dev cmake
 
 WORKDIR /usr/src/hebbot


### PR DESCRIPTION
buster is EOL, leading the build to fail due to "nightly" features being used from the perspective of the old rust version in the last `buster` image.