### PR TITLE
Clean up bits of code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -134,6 +134,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9dbc3a507a82b17ba0d98f6ce8fd6954ea0c8152e98009d36a40d8dcc8ce078a"
 
 [[package]]
+name = "assert_matches2"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15832d94c458da98cac0ffa6eca52cc19c2a3c6c951058500a5ae8f01f0fdf56"
+
+[[package]]
 name = "assign"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1314,6 +1320,7 @@ dependencies = [
 name = "hebbot"
 version = "2.1.0"
 dependencies = [
+ "assert_matches2",
  "async-process",
  "chrono",
  "log",
@@ -1322,7 +1329,6 @@ dependencies = [
  "minijinja",
  "minijinja-contrib",
  "pretty_env_logger",
- "rand 0.9.2",
  "regex",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1335,7 +1335,6 @@ dependencies = [
  "time",
  "tokio",
  "toml 0.9.7",
- "url",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,6 @@ edition = "2021"
 matrix-sdk = { version = "0.14", default-features = false }
 serde = "1.0"
 serde_json = "1.0"
-url = "2.2"
 tokio = { version="1.7", features = ["macros"] }
 log = "0.4"
 pretty_env_logger = "0.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,13 +14,15 @@ log = "0.4"
 pretty_env_logger = "0.5"
 chrono = { version = "0.4", features = ["serde"] }
 regex = "1.5"
-rand = "0.9"
 mime = "0.3"
 toml = "0.9"
 async-process = "2.2"
 minijinja = { version = "2.0.1", features = ["builtins", "debug", "deserialization", "json", "std_collections"] }
 minijinja-contrib = { version = "2.0.1", features = ["datetime", "rand"] }
 time = "0.3.36"
+
+[dev-dependencies]
+assert_matches2 = "0.1.2"
 
 [features]
 default = [

--- a/src/bot.rs
+++ b/src/bot.rs
@@ -155,12 +155,8 @@ impl Bot {
         #[rustfmt::skip]
         let (room, content) = match msg_type{
             BotMsgType::AdminRoomHtmlNotice => (&self.admin_room, RoomMessageEventContent::notice_html(msg, msg)),
-            BotMsgType::AdminRoomHtmlText => (&self.admin_room, RoomMessageEventContent::text_html(msg, msg)),
-            BotMsgType::AdminRoomPlainText => (&self.admin_room, RoomMessageEventContent::text_plain(msg)),
             BotMsgType::AdminRoomPlainNotice => (&self.admin_room, RoomMessageEventContent::notice_plain(msg)),
-            BotMsgType::ReportingRoomHtmlText => (&self.reporting_room, RoomMessageEventContent::text_html(msg, msg)),
             BotMsgType::ReportingRoomPlainText => (&self.reporting_room, RoomMessageEventContent::text_plain(msg)),
-            BotMsgType::ReportingRoomHtmlNotice => (&self.reporting_room, RoomMessageEventContent::notice_html(msg, msg)),
             BotMsgType::ReportingRoomPlainNotice => (&self.reporting_room, RoomMessageEventContent::notice_plain(msg)),
         };
 

--- a/src/bot_message_type.rs
+++ b/src/bot_message_type.rs
@@ -1,11 +1,7 @@
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum BotMessageType {
-    AdminRoomHtmlText,
-    AdminRoomPlainText,
     AdminRoomHtmlNotice,
     AdminRoomPlainNotice,
-    ReportingRoomHtmlText,
     ReportingRoomPlainText,
-    ReportingRoomHtmlNotice,
     ReportingRoomPlainNotice,
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -90,38 +90,29 @@ impl Config {
 
         // Check if something is missing / empty
         if config.notice_emoji.is_empty() {
-            warnings.insert(
-                0,
+            warnings.push(
                 "At least one emoji isn’t configured. The bot will not work properly.".to_string(),
             );
         }
 
         if config.editors.is_empty() {
-            warnings.insert(
-                0,
+            warnings.push(
                 "No editor is specified, the bot cannot be used without an editor".to_string(),
             );
         }
 
         if config.sections.is_empty() {
-            notes.insert(
-                0,
-                "No sections are configured in the configuration file.".to_string(),
-            );
+            notes.push("No sections are configured in the configuration file.".to_string());
         }
 
         if config.projects.is_empty() {
-            warnings.insert(
-                0,
-                "No projects are configured in the configuration file.".to_string(),
-            );
+            warnings.push("No projects are configured in the configuration file.".to_string());
         }
 
         let mut section_names = Vec::new();
         for section in &config.sections {
             if section.name.is_empty() {
-                warnings.insert(
-                    0,
+                warnings.push(
                     "Section without name found, this can lead to undefined behavior.".to_string(),
                 );
                 continue;
@@ -130,37 +121,29 @@ impl Config {
             section_names.insert(0, section.name.clone());
 
             if section.emoji.is_empty() {
-                warnings.insert(
-                    0,
-                    format!(
-                        "Section “{}” doesn’t have an emoji, this can lead to undefined behavior.",
-                        section.name
-                    ),
-                );
+                warnings.push(format!(
+                    "Section “{}” doesn’t have an emoji, this can lead to undefined behavior.",
+                    section.name
+                ));
             }
         }
 
         for project in &config.projects {
             if project.name.is_empty() {
-                warnings.insert(
-                    0,
+                warnings.push(
                     "Project without name found, this can lead to undefined behavior.".to_string(),
                 );
                 continue;
             }
 
             if project.emoji.is_empty() {
-                warnings.insert(
-                    0,
-                    format!(
-                        "Project “{}” doesn’t have an emoji, this can lead to undefined behavior.",
-                        project.name
-                    ),
-                );
+                warnings.push(format!(
+                    "Project “{}” doesn’t have an emoji, this can lead to undefined behavior.",
+                    project.name
+                ));
             }
             if project.default_section.is_empty() {
-                warnings.insert(
-                    0,
+                warnings.push(
                     format!(
                         "Project “{}” doesn’t have a default section, this can lead to undefined behavior.",
                         project.name
@@ -170,8 +153,7 @@ impl Config {
             }
 
             if !section_names.contains(&project.default_section) {
-                warnings.insert(
-                    0,
+                warnings.push(
                     format!(
                         "Project “{}” has an unknown default section “{}”, this can lead to undefined behavior.",
                         project.name,
@@ -208,22 +190,16 @@ impl Config {
         name_duplicates.dedup();
 
         if !emoji_duplicates.is_empty() {
-            warnings.insert(
-                0,
-                format!(
-                    "At least one emoji is duplicated, this can lead to undefined behavior: {:?} ",
-                    emoji_duplicates
-                ),
-            );
+            warnings.push(format!(
+                "At least one emoji is duplicated, this can lead to undefined behavior: {:?} ",
+                emoji_duplicates
+            ));
         }
         if !name_duplicates.is_empty() {
-            warnings.insert(
-                0,
-                format!(
-                    "At least one name is duplicated, this can lead to undefined behavior: {:?} ",
-                    name_duplicates
-                ),
-            );
+            warnings.push(format!(
+                "At least one name is duplicated, this can lead to undefined behavior: {:?} ",
+                name_duplicates
+            ));
         }
 
         ConfigResult {

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,5 +1,4 @@
 use matrix_sdk::ruma::{OwnedUserId, UserId};
-use rand::Rng;
 use serde::{Deserialize, Serialize};
 
 use std::collections::HashSet;
@@ -83,12 +82,6 @@ impl Config {
         }
 
         sections_for_this_reporter
-    }
-
-    pub fn random_verb(&self) -> String {
-        let mut rng = rand::rng();
-        let id = rng.random_range(0..self.verbs.len());
-        self.verbs[id].to_string()
     }
 
     fn validate_config(config: Self) -> ConfigResult {

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,4 @@
 #[derive(Debug)]
 pub enum Error {
     NewsEventIdNotFound,
-    RedactionEventIdNotFound,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,14 +13,14 @@ mod render;
 mod section;
 mod utils;
 
-pub use bot_message_type::BotMessageType;
-pub use config::Config;
-pub use error::Error;
-pub use news::News;
-pub use news_store::NewsStore;
-pub use project::Project;
-pub use reaction_type::ReactionType;
-pub use section::Section;
+use bot_message_type::BotMessageType;
+use config::Config;
+use error::Error;
+use news::News;
+use news_store::NewsStore;
+use project::Project;
+use reaction_type::ReactionType;
+use section::Section;
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() {

--- a/src/render.rs
+++ b/src/render.rs
@@ -143,12 +143,12 @@ pub fn render(
 
         // Check if the news entry has multiple project/information set
         if news.project_names().len() > 1 || news.section_names().len() > 1 {
-            warnings.insert(0, format!("[{}] News entry by {} has multiple project or section information set, it’ll appear multiple times. This is probably not wanted!", message_link, news.reporter_display_name));
+            warnings.push(format!("[{}] News entry by {} has multiple project or section information set, it’ll appear multiple times. This is probably not wanted!", message_link, news.reporter_display_name));
         }
 
         // Check if the news entry has at one project or section information added
         if news.project_names().is_empty() && news.section_names().is_empty() {
-            warnings.insert(0, format!("[{}] News entry by {} doesn’t have project/section information, it’ll not appear in the rendered markdown!", message_link, news.reporter_display_name));
+            warnings.push(format!("[{}] News entry by {} doesn’t have project/section information, it’ll not appear in the rendered markdown!", message_link, news.reporter_display_name));
             continue;
         }
 
@@ -161,7 +161,7 @@ pub fn render(
 
         // Add news entries without any project information (but with section information) directly to the specified `RenderSection`
         if news.project_names().is_empty() {
-            notes.insert(0, format!("[{}] News entry by {} doesn’t have project information, it’ll appear directly in the section without any project description.", message_link, news.reporter_display_name));
+            notes.push(format!("[{}] News entry by {} doesn’t have project information, it’ll appear directly in the section without any project description.", message_link, news.reporter_display_name));
 
             for section_name in news.section_names() {
                 let section = config.section_by_name(&section_name).unwrap();
@@ -194,7 +194,7 @@ pub fn render(
             // Handle news entries with sections which don't match the project default_section
             for section_name in news.section_names() {
                 if section_name != project.default_section {
-                    notes.insert(0, format!("[{}] News entry by {} gets added to the “{}” section, which is not the default section for this project.", message_link, news.reporter_display_name, section_name));
+                    notes.push( format!("[{}] News entry by {} gets added to the “{}” section, which is not the default section for this project.", message_link, news.reporter_display_name, section_name));
                     overwritten_section = true;
 
                     let custom_project_section_name =
@@ -278,7 +278,7 @@ pub fn render(
             "{} news are not included because of project/section assignment is missing. Use !status command to list them.",
             not_assigned
         );
-        warnings.insert(0, note);
+        warnings.push(note);
     }
 
     let summary = format!(
@@ -287,11 +287,7 @@ pub fn render(
         images.len(),
         videos.len(),
     );
-    notes.insert(0, summary);
-
-    // Rerverse order to make it more easy to read
-    warnings.reverse();
-    notes.reverse();
+    notes.push(summary);
 
     let rendered = JINJA_ENV
         .get_template("template")?


### PR DESCRIPTION
These are things that I noticed at first glance, there might be other opportunities to clean up.

1. Don't make imports at the root of the crate `pub`

    Cargo is smart, but not smart enough to check that an item cannot be used outside of the crate because the crate is a binary. So making an import `pub` at the root of the crate prevents the lint for unused code to work.

    This then removes everything that was detected as unused.

    I believe that this could be taken further by having no `pub` at all in the code, but at most `pub(crate)`, I am pretty sure that there is more unused code in the crate.
2. Remove unused `url` dependency, this is pretty straightforward.
3. Use `Vec::push(…)` instead of `Vec::insert(0, …)`

    `push` is the default API to use to insert items when working with a `Vec`, and `insert(0, …)` does the opposite.

    It is not clear to me why the insertion order was inverted for warnings and notes, but it seems to just complicate the code unnecessarily. Especially in one case where the order was reversed at the end.

     Although performance is probably not much of an issue for this bot, the docs say that `insert(0, …)` has the worst time complexity so there is no reason to use it as the default operation. If adding items in reverse order actually matters and we need to always insert items at the beginning, `VecDeque` is usually recommended instead.
