### PR TITLE
update curl hint for auth media

### DIFF
--- a/src/bot.rs
+++ b/src/bot.rs
@@ -849,11 +849,11 @@ impl Bot {
             )
             .await;
 
-            let mut curl_command = "curl".to_string();
+            let mut curl_command = "curl -H 'Authorization: Bearer <access token>'".to_string();
             for (filename, uri) in &files {
                 if uri.is_valid() {
                     let url = format!(
-                        "{}_matrix/media/r0/download/{}/{}",
+                        "{}_matrix/client/v1/media/download/{}/{}",
                         self.client.homeserver(),
                         uri.server_name().unwrap(),
                         uri.media_id().unwrap()


### PR DESCRIPTION
Improves the status quo towards solving #93 by at least not advertising a command that has no chance of working with a server running authenticated media